### PR TITLE
optimize app size be reduce firestore authentication dependencies

### DIFF
--- a/apps/webapp/src/app/auth/authentication.provider.tsx
+++ b/apps/webapp/src/app/auth/authentication.provider.tsx
@@ -3,7 +3,11 @@ import { FC, ReactNode, useEffect, useMemo, useReducer } from 'react';
 import { authenticationReducer } from './authentication.reducer';
 import { authenticationInitialState } from './authentication.initial';
 import { LoggerFactory } from '@consdata/logger-api';
-import { onAuthStateChanged } from 'firebase/auth';
+import {
+  browserPopupRedirectResolver,
+  getRedirectResult,
+  onAuthStateChanged,
+} from 'firebase/auth';
 import { useFirebaseAuthentication } from '../firebase/use-firebase-authentication';
 
 export interface AuthenticationProviderProps {
@@ -34,8 +38,12 @@ export const AuthenticationProvider: FC<AuthenticationProviderProps> = ({
           },
         });
       } else {
-        dispatch({
-          type: 'loggedOut',
+        getRedirectResult(auth, browserPopupRedirectResolver).then((result) => {
+          if (!result) {
+            dispatch({
+              type: 'loggedOut',
+            });
+          }
         });
       }
     });

--- a/apps/webapp/src/app/firebase/use-firebase-authentication.ts
+++ b/apps/webapp/src/app/firebase/use-firebase-authentication.ts
@@ -1,6 +1,17 @@
-import { getAuth } from 'firebase/auth';
+import {
+  browserLocalPersistence,
+  indexedDBLocalPersistence,
+  initializeAuth,
+} from 'firebase/auth';
 import { useFirebase } from './use-firebase';
+import { useMemo } from 'react';
 
 export const useFirebaseAuthentication = () => {
-  return getAuth(useFirebase());
+  const firebase = useFirebase();
+  const auth = useMemo(() => {
+    return initializeAuth(firebase, {
+      persistence: [indexedDBLocalPersistence, browserLocalPersistence],
+    });
+  }, [firebase]);
+  return auth;
 };

--- a/apps/webapp/src/app/login/login-google.tsx
+++ b/apps/webapp/src/app/login/login-google.tsx
@@ -1,7 +1,11 @@
 import { FC, useCallback } from 'react';
 import { LoginButton } from './login-button';
 import { useFirebaseAuthentication } from '../firebase/use-firebase-authentication';
-import { GoogleAuthProvider, signInWithRedirect } from 'firebase/auth';
+import {
+  browserPopupRedirectResolver,
+  GoogleAuthProvider,
+  signInWithRedirect,
+} from 'firebase/auth';
 import styled from '@emotion/styled';
 
 const GoogleLogoImage = styled.img`
@@ -13,7 +17,7 @@ export const LoginGoogle: FC = () => {
   const auth = useFirebaseAuthentication();
   const loginWithGoogle = useCallback(async () => {
     const provider = new GoogleAuthProvider();
-    await signInWithRedirect(auth, provider);
+    await signInWithRedirect(auth, provider, browserPopupRedirectResolver);
   }, [auth]);
   return (
     <LoginButton


### PR DESCRIPTION
lazy initialize redirect popup only for google authentication and prevent loading auth iframe on mobile
based on https://firebase.google.com/docs/auth/web/custom-dependencies